### PR TITLE
Fix Ultimatic mode dropping brief paddle taps (memory-latch bug)

### DIFF
--- a/App/app/cwkeyer.c
+++ b/App/app/cwkeyer.c
@@ -795,16 +795,15 @@ CW_Action_t CW_HandleState(void)
         }
 #endif
         // Sample paddles for memory logic - skip if we already know alternate is pending.
-        // Ultimatic never sets s_pending_alternate here, so it always reads (decisions
-        // are made fresh at the next gap, not queued via memory).
         if(!s_pending_alternate)
         {
             CW_ReadKeys(&in);
 
-            // Memory logic: depends on keyer mode and element type. Ultimatic has no
-            // memory queueing at all - it falls through after the read above.
-            if (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_A) {
-                // Type A: Purely edge detection for opposite paddle throughout element
+            // Memory logic: depends on keyer mode and element type.
+            if (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_A || gEeprom.CW_KEYER_MODE == CW_KEYER_MODE_ULTIMATIC) {
+                // Type A (and Ultimatic): edge detection for opposite paddle throughout
+                // element, so a brief tap that's released before this element ends is
+                // still remembered and fires next instead of being silently dropped.
                 if (s_active_is_dit && in.dah_rise) {
                     s_pending_alternate = true;
                 } else if (!s_active_is_dit && in.dit_rise) {
@@ -855,20 +854,18 @@ CW_Action_t CW_HandleState(void)
         const uint32_t elapsed_gap = millis_since(s_elem_start_count);
         
         // Read only if needed
-        if(!s_pending_alternate) // briand - lets try doing this regardless of mode // && (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_A))
+        if(!s_pending_alternate)
         {
             // keep doing sampling during gap for memory logic
             CW_ReadKeys(&in);
 
-            // Mode A style Edge detection for opposite key throughout element AND gap, but for
-            // both iambic modes. Ultimatic doesn't queue an alternate here - its next element
-            // is decided fresh below, every time, from current paddle state.
-            if (gEeprom.CW_KEYER_MODE != CW_KEYER_MODE_ULTIMATIC) {
-                if (s_active_is_dit && in.dah_rise) {
-                    s_pending_alternate = true;
-                } else if (!s_active_is_dit && in.dit_rise) {
-                    s_pending_alternate = true;
-                }
+            // Mode A style edge detection for opposite key throughout element AND gap,
+            // for iambic A/B and Ultimatic alike, so a brief tap released before the
+            // gap ends is still remembered instead of being silently dropped.
+            if (s_active_is_dit && in.dah_rise) {
+                s_pending_alternate = true;
+            } else if (!s_active_is_dit && in.dit_rise) {
+                s_pending_alternate = true;
             }
         }
         if (elapsed_gap >= s_gap_count) {


### PR DESCRIPTION
# Fix: Ultimatic mode drops brief paddle taps (memory-latch bug)

**File changed:** `App/app/cwkeyer.c`

## Summary

The Ultimatic keyer mode silently discards a brief opposite-paddle tap if it
is released before the currently-sending element (or the inter-element gap
that follows it) finishes. This is the same class of defect described in
[SP5DNA's k3ng_cw_keyer Ultimatic bug report, Bug #1](https://github.com/SP5DNA/k3ng_cw_keyer/blob/master/ultimatic_bug_report.md#bug-1--ultimatic-mode-entry-disables-ditdah-buffers):
the "memory latch" that lets a keyer remember a quick tap of the opposite
paddle was disabled for Ultimatic mode.

This firmware doesn't use k3ng's EEPROM `dit_buffer_off` / `dah_buffer_off`
flags — it samples the paddles live and uses an in-RAM `s_pending_alternate`
latch instead — but the effect of the bug, and the fix, are the same:
Ultimatic mode needs to *remember* an opposite-paddle edge event instead of
only checking "is the paddle still down right now?" at the decision point.

## Affected mode

`CW_KEYER_MODE_ULTIMATIC`

## Symptom vs. expected behaviour

| Observed (buggy) | Expected (correct) |
|---|---|
| Hold DAH, briefly press DIT and release it before DAH ends → only DAH is sent. DIT is silently discarded. | Hold DAH, briefly press DIT and release it before DAH ends → DAH–DIT is sent. The brief DIT press is remembered and fires right after the inter-element gap. |

## Root cause

`CW_HandleState()` implements a "memory" feature — an edge-triggered latch
(`s_pending_alternate`) that remembers when the opposite paddle was tapped
during the current element or the gap that follows, so a tap-and-release
that completes before the decision point isn't lost. This latch was
implemented for Iambic A and Iambic B, but was **explicitly excluded for
Ultimatic** in two places, based on the (incorrect) assumption that
Ultimatic should always decide "fresh" from the paddle state sampled at the
exact end of the element/gap:

**1. `CWK_STATE_ACTIVE_ELEMENT` (around line 797-828, before fix):**

```c
// Sample paddles for memory logic - skip if we already know alternate is pending.
// Ultimatic never sets s_pending_alternate here, so it always reads (decisions
// are made fresh at the next gap, not queued via memory).
if(!s_pending_alternate)
{
    CW_ReadKeys(&in);

    // Memory logic: depends on keyer mode and element type. Ultimatic has no
    // memory queueing at all - it falls through after the read above.
    if (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_A) {
        // Type A: Purely edge detection for opposite paddle throughout element
        if (s_active_is_dit && in.dah_rise) {
            s_pending_alternate = true;
        } else if (!s_active_is_dit && in.dit_rise) {
            s_pending_alternate = true;
        }
    } else if (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_B) {
        ...
```

**2. `CWK_STATE_INTER_ELEMENT_GAP` (around line 856-872, before fix):**

```c
if(!s_pending_alternate) // briand - lets try doing this regardless of mode // && (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_A))
{
    // keep doing sampling during gap for memory logic
    CW_ReadKeys(&in);

    // Mode A style Edge detection for opposite key throughout element AND gap, but for
    // both iambic modes. Ultimatic doesn't queue an alternate here - its next element
    // is decided fresh below, every time, from current paddle state.
    if (gEeprom.CW_KEYER_MODE != CW_KEYER_MODE_ULTIMATIC) {
        if (s_active_is_dit && in.dah_rise) {
            s_pending_alternate = true;
        } else if (!s_active_is_dit && in.dit_rise) {
            s_pending_alternate = true;
        }
    }
}
```

Because Ultimatic never set `s_pending_alternate`, a tap that started and
ended entirely within the current element (or entirely within the following
gap) left no trace by the time the FSM took its "fresh" sample
(`CW_ReadKeys()` at the gap-end check), so the tap was lost.

Note: this only affects the *brief-tap* case. The Ultimatic-specific
"whichever paddle was pressed most recently wins" tie-break for the case
where **both** paddles are still held down at the decision point (using
`in.last_is_dah`) is a separate, correctly-working piece of logic and was
**not** touched by this fix.

## Fix

Enable the same edge-triggered memory latch for `CW_KEYER_MODE_ULTIMATIC`
that Iambic A already uses, in both locations:

**1. `CWK_STATE_ACTIVE_ELEMENT` — after fix:**

```c
// Sample paddles for memory logic - skip if we already know alternate is pending.
if(!s_pending_alternate)
{
    CW_ReadKeys(&in);

    // Memory logic: depends on keyer mode and element type.
    if (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_A || gEeprom.CW_KEYER_MODE == CW_KEYER_MODE_ULTIMATIC) {
        // Type A (and Ultimatic): edge detection for opposite paddle throughout
        // element, so a brief tap that's released before this element ends is
        // still remembered and fires next instead of being silently dropped.
        if (s_active_is_dit && in.dah_rise) {
            s_pending_alternate = true;
        } else if (!s_active_is_dit && in.dit_rise) {
            s_pending_alternate = true;
        }
    } else if (gEeprom.CW_KEYER_MODE == CW_IAMBIC_MODE_B) {
        ...
```

**2. `CWK_STATE_INTER_ELEMENT_GAP` — after fix:**

```c
// Read only if needed
if(!s_pending_alternate)
{
    // keep doing sampling during gap for memory logic
    CW_ReadKeys(&in);

    // Mode A style edge detection for opposite key throughout element AND gap,
    // for iambic A/B and Ultimatic alike, so a brief tap released before the
    // gap ends is still remembered instead of being silently dropped.
    if (s_active_is_dit && in.dah_rise) {
        s_pending_alternate = true;
    } else if (!s_active_is_dit && in.dit_rise) {
        s_pending_alternate = true;
    }
}
```

The downstream consumer of the latch (`CWK_STATE_INTER_ELEMENT_GAP`'s
`if (s_pending_alternate) { ... have_next = true; }` block) needed no
changes — it already queues the opposite element correctly once the latch
is set, for any keyer mode.

## Why this doesn't break the Ultimatic "hold both paddles" tie-break

When both paddles are held continuously through the decision point, the
edge-triggered latch and the existing `in.last_is_dah` tie-break agree:
whichever paddle was pressed *later* both (a) causes the `_rise` edge that
sets `s_pending_alternate`, and (b) is the one `last_is_dah` reports as most
recent. So continuous-hold "squeeze" behaviour is unaffected; only the
previously-lost brief-tap case is fixed.

## Verification

Manual paddle test, matching the reproduction scenario from the referenced
k3ng bug report, with keyer mode set to Ultimatic:

| # | Action | Expected result |
|---|---|---|
| 1 | Hold DAH, tap DIT briefly, release DIT before DAH ends | DAH–DIT sent (not DAH alone) |
| 2 | Hold DAH, press DIT, release both during the inter-element gap | DAH–DIT sent |

Regression check:

| # | Action | Expected result |
|---|---|---|
| 3 | Iambic A / Iambic B modes, normal squeeze keying | Unchanged — these modes' logic branches were not modified |
| 4 | Ultimatic: hold DAH and DIT together continuously, release DAH first | Continues sending the more-recently-pressed paddle (DIT), unchanged tie-break behaviour |

## Note

This PR only addresses the "brief tap is lost" defect (equivalent to Bug #1
in the referenced report). It does not address the separate "phantom
element after both paddles released mid-element" defect (Bug #2 in the same
report) — the reproduction steps for that one (release **both** paddles
while the *second* element is still sounding) rely on a different code path
in this firmware and were not evaluated here.
